### PR TITLE
Исправил багу в collision-detection

### DIFF
--- a/stdsystems/collision-detection.go
+++ b/stdsystems/collision-detection.go
@@ -136,7 +136,7 @@ func (s *CollisionDetectionSystem) Run(dt time.Duration) {
 		wg.Add(1)
 
 		startIndex := i * chunkSize
-		endIndex := startIndex + chunkSize
+		endIndex := startIndex + chunkSize - 1
 		if i == numWorkers-1 { // have to set endIndex to entites lenght, if last worker
 			endIndex = entitiesLength
 		}

--- a/stdsystems/collision-detection.go
+++ b/stdsystems/collision-detection.go
@@ -129,12 +129,12 @@ func (s *CollisionDetectionSystem) Run(dt time.Duration) {
 	maxNumWorkers := runtime.NumCPU() * 4
 	entitiesLength := len(entities)
 	// get minimum 1 worker for small amount of entities, and maximum maxNumWorkers for a lot entities
-	numWorkers := max(min(entitiesLength/10, maxNumWorkers), 1)
+	numWorkers := max(min(entitiesLength/32, maxNumWorkers), 1)
 	chunkSize := entitiesLength / numWorkers
 
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
+	wg.Add(numWorkers)
 
+	for i := 0; i < numWorkers; i++ {
 		startIndex := i * chunkSize
 		endIndex := startIndex + chunkSize - 1
 		if i == numWorkers-1 { // have to set endIndex to entites lenght, if last worker


### PR DESCRIPTION
Сделано 2 вещи

1. Количество воркеров выбирается относительно того, сколько сущностей надо обработать. Нет смысла делать условно 8 воркеров, если у вас 5 сущностей. Сейчас чем больше сущностей надо обработать, тем больше воркеров будет запущено, но с макс лимитом.
2. Правильная выборка сущностей для каждого воркера, исправил ошибку когда происходил выход за границу.